### PR TITLE
Rewritten update in marker sensor to take a timestamp for the data

### DIFF
--- a/IRescue/Unity/Assets/Scripts/Unity/SensorControllers/MarkerSensorController.cs
+++ b/IRescue/Unity/Assets/Scripts/Unity/SensorControllers/MarkerSensorController.cs
@@ -106,7 +106,7 @@ public class MarkerSensorController : AbstractSensorController
     /// </summary>
     public void Update()
     {
-        this.markerSensor.UpdateLocations(this.GetVisibleMarkers());
+        this.markerSensor.UpdateLocations(IRescue.Core.Utils.StopwatchSingleton.Time, this.GetVisibleMarkers());
     }
 
     /// <summary>

--- a/IRescue/UserLocalisation/Sensors/Marker/MarkerSensor.cs
+++ b/IRescue/UserLocalisation/Sensors/Marker/MarkerSensor.cs
@@ -94,12 +94,12 @@ namespace IRescue.UserLocalisation.Sensors.Marker
         public int Measurements { get; private set; }
 
         /// <summary>
-        ///   Update the locations derived from Markers.
+        /// Update the locations derived from Markers.
         /// </summary>
+        /// <param name="timeStamp">Time stamp at which the measurement was taken.</param>
         /// <param name="visibleMarkerIds">Dictionary of the ids and transforms ((x,y,z), (pitch, yaw, rotation) in degrees) of the visible Markers.</param>
-        public void UpdateLocations(Dictionary<int, Pose> visibleMarkerIds)
+        public void UpdateLocations(long timeStamp, Dictionary<int, Pose> visibleMarkerIds)
         {
-            long timeStamp = StopwatchSingleton.Time;
             foreach (KeyValuePair<int, Pose> pair in visibleMarkerIds)
             {
                 try

--- a/IRescue/UserLocalisation/Tests/UserLocalisation.Test/Sensors/Marker/MarkerSensorTest.cs
+++ b/IRescue/UserLocalisation/Tests/UserLocalisation.Test/Sensors/Marker/MarkerSensorTest.cs
@@ -25,6 +25,11 @@ namespace UserLocalisation.Test.Sensors.Marker
         private float std = 20.5f;
 
         /// <summary>
+        /// The default time stamp to use for measurements.
+        /// </summary>
+        private long defaultTimeStamp = 1;
+
+        /// <summary>
         /// Error margin for the rotation
         /// </summary>
         private float epsilon = 2;
@@ -58,7 +63,7 @@ namespace UserLocalisation.Test.Sensors.Marker
             dic.Add(1, new Pose(new Vector3(1, 2, 3), new Vector3(90, 180, 270)));
             Pose pose2 = new Pose(new Vector3(4, 5, 6), new Vector3(90, 180, 270));
             dic.Add(2, pose2);
-            this.sensor.UpdateLocations(dic);
+            this.sensor.UpdateLocations(this.defaultTimeStamp, dic);
             Assert.AreEqual(270, this.sensor.GetLastOrientation().Data.X, this.epsilon);
         }
 
@@ -72,7 +77,7 @@ namespace UserLocalisation.Test.Sensors.Marker
             dic.Add(1, new Pose(new Vector3(1, 2, 3), new Vector3(90, 180, 270)));
             Pose pose2 = new Pose(new Vector3(4, 5, 6), new Vector3(90, 180, 270));
             dic.Add(-1337, pose2);
-            this.sensor.UpdateLocations(dic);
+            this.sensor.UpdateLocations(this.defaultTimeStamp, dic);
             Assert.AreEqual(270, this.sensor.GetLastOrientation().Data.X, this.epsilon);
         }
 
@@ -86,7 +91,7 @@ namespace UserLocalisation.Test.Sensors.Marker
             dic.Add(1, new Pose(new Vector3(1, 2, 3), new Vector3(90, 180, 270)));
             Pose pose2 = new Pose(new Vector3(4, 5, 6), new Vector3(90, 180, 270));
             dic.Add(0, pose2);
-            this.sensor.UpdateLocations(dic);
+            this.sensor.UpdateLocations(this.defaultTimeStamp, dic);
             Assert.AreEqual(18f, this.sensor.GetLastPosition().Data.X, this.epsilonP);
         }
 
@@ -100,7 +105,7 @@ namespace UserLocalisation.Test.Sensors.Marker
             dic.Add(1, new Pose(new Vector3(1, 2, 3), new Vector3(90, 180, 270)));
             Pose pose2 = new Pose(new Vector3(4, 5, 6), new Vector3(90, 180, 270));
             dic.Add(0, pose2);
-            this.sensor.UpdateLocations(dic);
+            this.sensor.UpdateLocations(this.defaultTimeStamp, dic);
             Assert.AreEqual(2, this.sensor.GetPositions(0, long.MaxValue).Count);
         }
 
@@ -114,7 +119,7 @@ namespace UserLocalisation.Test.Sensors.Marker
             dic.Add(1, new Pose(new Vector3(1, 2, 3), new Vector3(90, 180, 270)));
             Pose pose2 = new Pose(new Vector3(4, 5, 6), new Vector3(90, 180, 270));
             dic.Add(0, pose2);
-            this.sensor.UpdateLocations(dic);
+            this.sensor.UpdateLocations(this.defaultTimeStamp, dic);
             Assert.AreEqual(2, this.sensor.GetAllPositions().Count);
         }
 
@@ -128,7 +133,7 @@ namespace UserLocalisation.Test.Sensors.Marker
             dic.Add(1, new Pose(new Vector3(1, 2, 3), new Vector3(90, 180, 270)));
             Pose pose2 = new Pose(new Vector3(4, 5, 6), new Vector3(910, 180, 270));
             dic.Add(0, pose2);
-            this.sensor.UpdateLocations(dic);
+            this.sensor.UpdateLocations(this.defaultTimeStamp, dic);
             Assert.Null(this.sensor.GetOrientation(-50));
         }
 
@@ -142,7 +147,7 @@ namespace UserLocalisation.Test.Sensors.Marker
             dic.Add(1, new Pose(new Vector3(1, 2, 3), new Vector3(90, 180, 270)));
             Pose pose2 = new Pose(new Vector3(4, 5, 6), new Vector3(90, 180, 270));
             dic.Add(0, pose2);
-            this.sensor.UpdateLocations(dic);
+            this.sensor.UpdateLocations(this.defaultTimeStamp, dic);
             Assert.AreEqual(2, this.sensor.GetOrientations(0, long.MaxValue).Count);
         }
 
@@ -156,7 +161,7 @@ namespace UserLocalisation.Test.Sensors.Marker
             dic.Add(1, new Pose(new Vector3(1, 2, 3), new Vector3(90, 180, 270)));
             Pose pose2 = new Pose(new Vector3(4, 5, 6), new Vector3(90, 180, 270));
             dic.Add(0, pose2);
-            this.sensor.UpdateLocations(dic);
+            this.sensor.UpdateLocations(this.defaultTimeStamp, dic);
             Assert.AreEqual(2, this.sensor.GetAllOrientations().Count);
         }
 
@@ -170,7 +175,7 @@ namespace UserLocalisation.Test.Sensors.Marker
             dic.Add(1, new Pose(new Vector3(1, 2, 3), new Vector3(90, 180, 270)));
             Pose pose2 = new Pose(new Vector3(4, 5, 6), new Vector3(90, 180, 270));
             dic.Add(0, pose2);
-            this.sensor.UpdateLocations(dic);
+            this.sensor.UpdateLocations(this.defaultTimeStamp, dic);
             Assert.Null(this.sensor.GetPosition(-50));
         }
 
@@ -185,11 +190,11 @@ namespace UserLocalisation.Test.Sensors.Marker
             dic.Add(1, new Pose(new Vector3(1, 2, 3), new Vector3(90, 180, 270)));
             Pose pose2 = new Pose(new Vector3(4, 5, 6), new Vector3(90, 180, 270));
             dic.Add(0, pose2);
-            this.sensor.UpdateLocations(dic);
-            this.sensor.UpdateLocations(dic);
-            this.sensor.UpdateLocations(dic);
-            this.sensor.UpdateLocations(dic);
-            this.sensor.UpdateLocations(dic);
+            this.sensor.UpdateLocations(this.defaultTimeStamp, dic);
+            this.sensor.UpdateLocations(this.defaultTimeStamp, dic);
+            this.sensor.UpdateLocations(this.defaultTimeStamp, dic);
+            this.sensor.UpdateLocations(this.defaultTimeStamp, dic);
+            this.sensor.UpdateLocations(this.defaultTimeStamp, dic);
             Assert.AreEqual(6, this.sensor.GetAllOrientations().Count);
         }
 
@@ -204,12 +209,12 @@ namespace UserLocalisation.Test.Sensors.Marker
             dic.Add(1, new Pose(new Vector3(1, 2, 3), new Vector3(90, 180, 270)));
             Pose pose2 = new Pose(new Vector3(4, 5, 6), new Vector3(90, 180, 270));
             dic.Add(0, pose2);
-            this.sensor.UpdateLocations(dic);
-            this.sensor.UpdateLocations(dic);
-            this.sensor.UpdateLocations(dic);
-            this.sensor.UpdateLocations(dic);
-            this.sensor.UpdateLocations(dic);
-            this.sensor.UpdateLocations(new Dictionary<int, Pose>());
+            this.sensor.UpdateLocations(this.defaultTimeStamp, dic);
+            this.sensor.UpdateLocations(this.defaultTimeStamp, dic);
+            this.sensor.UpdateLocations(this.defaultTimeStamp, dic);
+            this.sensor.UpdateLocations(this.defaultTimeStamp, dic);
+            this.sensor.UpdateLocations(this.defaultTimeStamp, dic);
+            this.sensor.UpdateLocations(this.defaultTimeStamp, new Dictionary<int, Pose>());
             Assert.AreEqual(6, this.sensor.GetAllOrientations().Count);
         }
     }


### PR DESCRIPTION
Fixes #41 
MarkerSensor now takes a time stamp when adding the measurements. Rewritten the tests and rewritten the unity controller to take the current timestamp from the stopwatch when updating the markers.
