### PR TITLE
Fixed time stamp bug IMUSource

### DIFF
--- a/IRescue/UserLocalisation/Sensors/IMU/IMUSource.cs
+++ b/IRescue/UserLocalisation/Sensors/IMU/IMUSource.cs
@@ -479,9 +479,9 @@ namespace IRescue.UserLocalisation.Sensors.IMU
         /// </summary>
         /// <param name="ms">The milliseconds to convert.</param>
         /// <returns>Converted milliseconds in seconds</returns>
-        private long MilliSecondsToSeconds(long ms)
+        private float MilliSecondsToSeconds(long ms)
         {
-            return ms / 1000;
+            return ms / 1000f;
         }
 
         /// <summary>

--- a/IRescue/UserLocalisation/Tests/UserLocalisation.Test/Sensors/IMU/IMUSourceTest.cs
+++ b/IRescue/UserLocalisation/Tests/UserLocalisation.Test/Sensors/IMU/IMUSourceTest.cs
@@ -244,6 +244,22 @@ namespace UserLocalisation.Test.Sensors.IMU
         }
 
         /// <summary>
+        /// Test that get last velocity returns the correct velocity when data is supplied and the
+        /// time stamp is smaller than one second.
+        /// </summary>
+        [Test]
+        public void GetLastVelocityMillisecondsTest()
+        {
+            Vector3 acc0 = new Vector3(0, 0, 0);
+            Vector3 acc1 = new Vector3(1, 2, 3);
+            this.source.AddMeasurements(0, acc0, this.zeroOrientation);
+            this.source.AddMeasurements(100, acc1, this.zeroOrientation);
+            Measurement<Vector3> res = this.source.GetLastVelocity();
+            this.AssertVectorAreEqual(new Vector3(0.05f, 0.1f, 0.15f), res.Data);
+            Assert.AreEqual(100, res.TimeStamp);
+        }
+
+        /// <summary>
         /// Test that get velocity at a specified time stamp returns the correct velocity.
         /// </summary>
         [Test]


### PR DESCRIPTION
Fixed a bug that the conversion from milliseconds to seconds resulted in zero for time stamps smaller than 1000.
