### PR TITLE
Fixes #48 MarkerSensor rotation

### DIFF
--- a/IRescue/Unity/Assets/Scripts/Unity/SensorControllers/MarkerSensorController.cs
+++ b/IRescue/Unity/Assets/Scripts/Unity/SensorControllers/MarkerSensorController.cs
@@ -114,7 +114,7 @@ public class MarkerSensorController : AbstractSensorController
 
             Vector3 rotation = new Vector3(
                 this.markerTransform.eulerAngles.x - MetaOrientation.x, 
-                this.markerTransform.eulerAngles.y - MetaOrientation.y, 
+                180 + this.markerTransform.eulerAngles.y - MetaOrientation.y, 
                 this.markerTransform.eulerAngles.z - MetaOrientation.z);
             visibleMarkerTransforms.Add(markerId, new Pose(position, rotation));
         }


### PR DESCRIPTION
Fixes #48. Added 180 degrees to the default Y rotation as the marker is always facing the user when it is seen.
