### PR TITLE
Fixed the marker rotation from unitys zxy rotation to xyz rotation

### DIFF
--- a/IRescue/Unity/Assets/Scripts/Unity/SensorControllers/MarkerSensorController.cs
+++ b/IRescue/Unity/Assets/Scripts/Unity/SensorControllers/MarkerSensorController.cs
@@ -2,12 +2,16 @@
 // Copyright (c) Delft University of Technology. All rights reserved.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using Assets.Scripts.Unity.SensorControllers;
 using IRescue.Core.DataTypes;
 using IRescue.Core.Distributions;
 using IRescue.UserLocalisation.Sensors;
 using IRescue.UserLocalisation.Sensors.Marker;
+
+using MathNet.Numerics.LinearAlgebra;
+
 using Meta;
 using UnityEngine;
 using Vector3 = IRescue.Core.DataTypes.Vector3;
@@ -104,7 +108,12 @@ public class MarkerSensorController : AbstractSensorController
 
             // TODO optimize?
             TransformationMatrix Tcm = new TransformationMatrix(this.markerTransform.position.x, this.markerTransform.position.y, this.markerTransform.position.z, this.markerTransform.eulerAngles.x, this.markerTransform.eulerAngles.y, this.markerTransform.eulerAngles.z);
-            TransformationMatrix Tcu = new TransformationMatrix(0, 0, 0, MetaOrientation.x, MetaOrientation.y, MetaOrientation.z);
+            TransformationMatrix Tcu = new TransformationMatrix();
+            TransformationMatrix Tcux = new TransformationMatrix(0, 0, 0, MetaOrientation.x, 0, 0);
+            TransformationMatrix Tcuy = new TransformationMatrix(0, 0, 0, 0, MetaOrientation.y, 0);
+            TransformationMatrix Tcuz = new TransformationMatrix(0, 0, 0, 0, 0, MetaOrientation.x);
+            Tcuy.Multiply(Tcux).Multiply(Tcuz, Tcu);
+
             TransformationMatrix Tum = new TransformationMatrix();
             Tum[3, 3] = 1;
             Tcu.Inverse().Multiply(Tcm, Tum);
@@ -114,11 +123,18 @@ public class MarkerSensorController : AbstractSensorController
             Tum.Multiply(relativeMarkerPosition, relativeMarkerPosition);
             // TODO fix to create Vector3 by copying from Vector4?
             Vector3 position = new Vector3(relativeMarkerPosition.X, relativeMarkerPosition.Y, relativeMarkerPosition.Z);
-
             Vector3 rotation = new Vector3(
                 this.markerTransform.eulerAngles.x - MetaOrientation.x, 
-                180 + this.markerTransform.eulerAngles.y - MetaOrientation.y, 
+                this.markerTransform.eulerAngles.y - MetaOrientation.y, 
                 this.markerTransform.eulerAngles.z - MetaOrientation.z);
+
+            RotationMatrix xyzRotation = new RotationMatrix();
+            RotationMatrix xr = new RotationMatrix(rotation.X,0,0);
+            RotationMatrix yr = new RotationMatrix(0,rotation.Y,0);
+            RotationMatrix zr = new RotationMatrix(0,0,rotation.Z);
+
+            yr.Multiply(xr).Multiply(zr).Multiply(new RotationMatrix(0,180,0), xyzRotation);
+            rotation = new Vector3((float)MathNet.Numerics.Trig.RadianToDegree(Math.Atan2(xyzRotation[2, 1], xyzRotation[2, 2])), (float)MathNet.Numerics.Trig.RadianToDegree(Math.Atan2(-1 * xyzRotation[2, 0], Math.Sqrt(Math.Pow(xyzRotation[2, 1], 2) + Math.Pow(xyzRotation[2, 2], 2)))), (float)MathNet.Numerics.Trig.RadianToDegree(Math.Atan2(xyzRotation[1, 0], xyzRotation[0, 0])));
             visibleMarkerTransforms.Add(markerId, new Pose(position, rotation));
         }
 

--- a/IRescue/Unity/Assets/Scripts/Unity/SourceCouplers/ParticleFilterCoupler.cs
+++ b/IRescue/Unity/Assets/Scripts/Unity/SourceCouplers/ParticleFilterCoupler.cs
@@ -30,8 +30,8 @@ public class ParticleFilterCoupler : AbstractLocalizerCoupler
     /// </summary>
     public ParticleFilterCoupler()
     {
-        FieldSize fieldSize = new FieldSize() { Xmax = 4, Xmin = 0, Ymax = 2, Ymin = 0, Zmax = 4, Zmin = 0 };
-        int particleamount = 30;
+        FieldSize fieldSize = new FieldSize() { Xmax = 5, Xmin = 0, Ymax = 2, Ymin = 0, Zmax = 5, Zmin = 0 };
+        int particleamount = 300;
         IParticleGenerator prtclgen = new RandomParticleGenerator(new ContinuousUniform());
         INoiseGenerator noisegen = new RandomNoiseGenerator(new ContinuousUniform());
         IResampler resampler = new MultinomialResampler();


### PR DESCRIPTION
Unity rotations are in the form of zxy and our implementation is in xyz order. The unity rotations are now changed to xyz rotations.
